### PR TITLE
Register SNOMEDconcept S3 inheritance with S4

### DIFF
--- a/R/SNOMEDcodelist.R
+++ b/R/SNOMEDcodelist.R
@@ -279,6 +279,8 @@ SNOMEDcodelist <- function(x, include_desc = FALSE,
 	out[]
 }
 
+methods::setOldClass(c("SNOMEDconcept", "integer64"))
+
 #' @rdname SNOMEDconcept
 #' @family SNOMEDconcept functions
 #' @export


### PR DESCRIPTION
We found that using `as(x, "integer64")` doesn't work due to some S4 quirk.

One way around this is to register the S3 inheritance structure with S4 as done here. I'm not sure it's strictly necessary, but I don't think either that there's any harm.

Bug in bit64: https://github.com/r-lib/bit64/issues/298
Potential bug report in r-devel: https://stat.ethz.ch/pipermail/r-devel/2026-March/084409.html